### PR TITLE
Fix incrementAndInvoice function

### DIFF
--- a/src/Subscription.php
+++ b/src/Subscription.php
@@ -98,12 +98,14 @@ class Subscription extends Model
     /**
      *  Increment the quantity of the subscription. and invoice immediately.
      *
-     * @param  int|null  $quantity
+     * @param  int  $count
      * @return $this
      */
-    public function incrementAndInvoice($quantity = null)
+    public function incrementAndInvoice($count = 1)
     {
-        $this->incrementQuantity($quantity);
+        $this->incrementQuantity($count);
+
+        $this->user->invoice();
 
         return $this;
     }


### PR DESCRIPTION
Calling incrementAndInvoice without an argument would result in incrementQuantity being called with a null value, which is unexpected behaviour in my mind. Updating incrementAndInvoice to accept a count argument makes it function like the other methods and is thus much more intuitive.

Secondly, this function wasn't actually invoicing the user as one is led to believe by the function name.
